### PR TITLE
Add missing 0x72 value for Libp2pKey

### DIFF
--- a/src/Multiformats.Codec/MulticodecCode.cs
+++ b/src/Multiformats.Codec/MulticodecCode.cs
@@ -91,6 +91,8 @@ namespace Multiformats.Codec
         MerkleDAGProtobuf = 0x70,
         [StringValue("dag-cbor")]
         MerkleDAGCBOR = 0x71,
+        [StringValue("libp2p-key")]
+        Libp2pKey = 0x72,
         [StringValue("dag-json")]
         MerkleDAGJSON = 0x129,
         [StringValue("eth-block")]


### PR DESCRIPTION
In reviewing go-multicodec vs. this library, this value is missing from the enum, which would be needed for a libp2p C# port.